### PR TITLE
Added login/logout + ability to like/dislike posts on 9gag

### DIFF
--- a/sailfish/harbour-gagbook.pro
+++ b/sailfish/harbour-gagbook.pro
@@ -21,7 +21,8 @@ HEADERS += \
     ../src/networkmanager.h \
     ../src/gagimagedownloader.h \
     ../src/gagcookiejar.h \
-    ../src/volumekeylistener.h
+    ../src/volumekeylistener.h \
+    ../src/votingmanager.h
 
 SOURCES += main.cpp \
     ../src/qmlutils.cpp \
@@ -35,7 +36,8 @@ SOURCES += main.cpp \
     ../src/networkmanager.cpp \
     ../src/gagimagedownloader.cpp \
     ../src/gagcookiejar.cpp \
-    ../src/volumekeylistener.cpp
+    ../src/volumekeylistener.cpp \
+    ../src/votingmanager.cpp
 
 # Qt-Json
 HEADERS += ../qt-json/json.h
@@ -62,4 +64,5 @@ OTHER_FILES += \
     qml/OpenLinkDialog.qml \
     qml/SectionPage.qml \
     qml/SimpleListItem.qml \
+    qml/LoginPage.qml \
     qml/Images/icon-gif-play.png

--- a/sailfish/main.cpp
+++ b/sailfish/main.cpp
@@ -38,6 +38,7 @@
 #include "src/networkmanager.h"
 #include "src/appsettings.h"
 #include "src/volumekeylistener.h"
+#include "src/votingmanager.h"
 
 Q_DECL_EXPORT int main(int argc, char *argv[])
 {
@@ -71,6 +72,7 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
     qmlRegisterType<GagBookManager>("harbour.gagbook.Core", 1, 0, "GagBookManager");
     qmlRegisterType<GagModel>("harbour.gagbook.Core", 1, 0, "GagModel");
     qmlRegisterType<AppSettings>("harbour.gagbook.Core", 1, 0, "AppSettings");
+    qmlRegisterType<VotingManager>("harbour.gagbook.Core", 1, 0, "VotingManager");
 
     view->setSource(SailfishApp::pathTo("qml/main.qml"));
     view->show();

--- a/sailfish/qml/AppSettingsPage.qml
+++ b/sailfish/qml/AppSettingsPage.qml
@@ -32,6 +32,8 @@ import harbour.gagbook.Core 1.0
 Page {
     id: settingsPage
 
+    LoginPage {id: loginPage}
+
     SilicaFlickable {
         id: settingsFlickable
         anchors.fill: parent
@@ -66,8 +68,20 @@ Page {
                 checked: appSettings.scrollWithVolumeKeys
                 onCheckedChanged: appSettings.scrollWithVolumeKeys = checked;
             }
+
+            Button {
+                anchors.horizontalCenter: parent.horizontalCenter
+                text: gagbookManager.loggedIn ? "Log out from 9gag.com" : "Login to 9gag.com"
+                onClicked: gagbookManager.loggedIn ? gagbookManager.logout() : pageStack.push(loginPage);
+            }
         }
 
         VerticalScrollDecorator {}
+    }
+
+    Component.onCompleted: {
+       // loginPage.accepted.connect(function() {
+       //     console.log("accepted login");
+       // });
     }
 }

--- a/sailfish/qml/AppSettingsPage.qml
+++ b/sailfish/qml/AppSettingsPage.qml
@@ -71,8 +71,17 @@ Page {
 
             Button {
                 anchors.horizontalCenter: parent.horizontalCenter
-                text: gagbookManager.loggedIn ? "Log out from 9gag.com" : "Login to 9gag.com"
+                text: gagbookManager.loggedIn ? "Log out " + appSettings.username : "Login to 9gag.com"
                 onClicked: gagbookManager.loggedIn ? gagbookManager.logout() : pageStack.push(loginPage);
+            }
+            Text {
+                id: wrongLoginDetails
+                anchors.horizontalCenter: parent.horizontalCenter
+                width: parent.width
+                text: "Wrong username or password, please try again..."
+                font.pixelSize: constant.fontSizeSmall
+                color: "red"
+                visible: false
             }
         }
 
@@ -80,8 +89,18 @@ Page {
     }
 
     Component.onCompleted: {
-       // loginPage.accepted.connect(function() {
-       //     console.log("accepted login");
-       // });
+        loginPage.accepted.connect(function() {
+            console.log("accepted login for " + appSettings.username);
+        });
+
+        gagbookManager.loggedInChanged.connect(onLoggedInChanged);
+    }
+
+    function onLoggedInChanged() {
+        console.log("logged in changed: " + gagbookManager.loggedIn);
+        if (!gagbookManager.loggedIn)
+            wrongLoginDetails.visible = true;
+        else
+            wrongLoginDetails.visible = false;
     }
 }

--- a/sailfish/qml/GagDelegate.qml
+++ b/sailfish/qml/GagDelegate.qml
@@ -278,6 +278,33 @@ Item {
             spacing: constant.paddingMedium
 
             IconButton {
+                id: likeButton
+                icon.source: "image://theme/icon-m-up"
+                highlighted: model.isLiked
+                onClicked: {
+                    console.log("clicked Like with id: " + model.id + ", current: " + model.isLiked);
+                    if (gagbookManager.loggedIn){
+                        votingManager.setLike(model.id, !model.isLiked);
+                        model.isLiked = !model.isLiked;
+                    }
+                    else
+                        infoBanner.alert("You must login before you can vote. Go to settings and log in.");
+                }
+            }
+            IconButton {
+                icon.source: "image://theme/icon-m-down"
+                highlighted: model.isDisliked
+                onClicked: {
+                    if (gagbookManager.loggedIn){
+                        votingManager.setDislike(model.id, !model.isDisliked);
+                        model.isDisliked = !model.isDisliked;
+                    }
+                    else
+                        infoBanner.alert("You must login before you can vote. Go to settings and log in.");
+                }
+            }
+
+            IconButton {
                 icon.height: Theme.iconSizeMedium; icon.width: Theme.iconSizeMedium
                 icon.source: "image://theme/icon-m-message"
                 onClicked: pageStack.push(Qt.resolvedUrl("CommentsPage.qml"), { gagURL: model.url })
@@ -326,4 +353,30 @@ Item {
         anchors { left: parent.left; right: parent.right; bottom: parent.bottom }
         color: Theme.secondaryColor
     }
+
+    Component.onCompleted: {
+        //votingManager.invalidVote.connect(onInvalidVote);
+        //votingManager.liked.connect(onLiked);
+        //votingManager.disliked.connect(onDisliked);
+        //votingManager.unliked.connect(onUnliked);
+    }
+
+    function onInvalidVote() {
+        console.log("reporting invalid vote");
+    }
+    function onLiked() {
+        console.log("reporting liked vote");
+        model.isLiked = true;
+        model.isDisliked = false;
+    }
+    function onUnliked() {
+        console.log("reporting unliked vote");
+        model.isLiked = false;
+    }
+    function onDisliked() {
+        console.log("reporting disliked vote");
+        model.isLiked = false;
+        model.isDisliked = true;
+    }
+
 }

--- a/sailfish/qml/LoginPage.qml
+++ b/sailfish/qml/LoginPage.qml
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2014 Bob Jelica (@b0bben)
+ * All rights reserved.
+ *
+ * This file is part of GagBook.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import QtQuick 2.0
+import Sailfish.Silica 1.0
+
+Dialog {
+    property string username
+    property string password
+
+    Column {
+        spacing: 10
+        anchors.fill: parent
+
+        DialogHeader {
+            acceptText: "Login"
+        }
+
+        TextField {
+            id: usernameField
+            width: 480
+            inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase
+            placeholderText: "9gag.com username"
+        }
+
+        TextField {
+            id: passwordField
+            width: 480
+            echoMode: TextInput.Password
+            placeholderText: "Password"
+        }
+        Text {
+            id: wrongLoginDetails
+            text: "Wrong username or password"
+            color: "red"
+            visible: false
+        }
+    }
+
+    onDone: {
+        if (result == DialogResult.Accepted) {
+            console.log("accepted dialog");
+            username = usernameField.text;
+            password = passwordField.text;
+
+            passwordField.text = "Password";
+
+            gagbookManager.login(username, password);
+            acceptPending = true;
+        }
+    }
+
+    Connections {
+        target: gagbookManager
+        onLoggedInChanged: {
+            if (!gagbookManager.loggedIn)
+                wrongLoginDetails.visible = true;
+            else {
+                wrongLoginDetails.visible = false;
+                accept();
+            }
+        }
+    }
+}
+

--- a/sailfish/qml/LoginPage.qml
+++ b/sailfish/qml/LoginPage.qml
@@ -43,6 +43,7 @@ Dialog {
         TextField {
             id: usernameField
             width: 480
+            text: appSettings.username ? appSettings.username : ""
             inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase
             placeholderText: "9gag.com username"
         }
@@ -52,12 +53,6 @@ Dialog {
             width: 480
             echoMode: TextInput.Password
             placeholderText: "Password"
-        }
-        Text {
-            id: wrongLoginDetails
-            text: "Wrong username or password"
-            color: "red"
-            visible: false
         }
     }
 
@@ -70,19 +65,6 @@ Dialog {
             passwordField.text = "Password";
 
             gagbookManager.login(username, password);
-            acceptPending = true;
-        }
-    }
-
-    Connections {
-        target: gagbookManager
-        onLoggedInChanged: {
-            if (!gagbookManager.loggedIn)
-                wrongLoginDetails.visible = true;
-            else {
-                wrongLoginDetails.visible = false;
-                accept();
-            }
         }
     }
 }

--- a/sailfish/qml/MainPage.qml
+++ b/sailfish/qml/MainPage.qml
@@ -106,7 +106,7 @@ Page {
         PullDownMenu {
             MenuItem {
                 text: "About GagBook"
-                onClicked: pageStack.push(Qt.resolvedUrl("AboutPage.qml"))
+                onClicked: pageStack.push(Qt.resolvedUrl("AboutPage.qml"));
             }
             MenuItem {
                 text: "Settings"

--- a/sailfish/qml/main.qml
+++ b/sailfish/qml/main.qml
@@ -43,4 +43,8 @@ ApplicationWindow {
         id: gagbookManager
         settings: AppSettings { id: appSettings }
     }
+
+    VotingManager {
+        id: votingManager
+    }
 }

--- a/src/appsettings.cpp
+++ b/src/appsettings.cpp
@@ -58,6 +58,8 @@ AppSettings::AppSettings(QObject *parent) :
 
     if (m_sections.isEmpty())
         setSections(defaultSections());
+
+    m_username = m_settings->value("username").toString();
 }
 
 bool AppSettings::isWhiteTheme() const
@@ -113,5 +115,19 @@ void AppSettings::setSections(const QStringList &sections)
         m_sections = sections;
         m_settings->setValue("sections", m_sections);
         emit sectionsChanged();
+    }
+}
+
+QString AppSettings::username() const
+{
+    return m_username;
+}
+
+void AppSettings::setUsername(const QString &username)
+{
+    if (m_username != username) {
+        m_username = username;
+        m_settings->setValue("username", username);
+        emit usernameChanged();
     }
 }

--- a/src/appsettings.h
+++ b/src/appsettings.h
@@ -44,6 +44,7 @@ class AppSettings : public QObject
     Q_PROPERTY(bool scrollWithVolumeKeys READ scrollWithVolumeKeys WRITE setScrollWithVolumeKeys
                NOTIFY scrollWithVolumeKeysChanged)
     Q_PROPERTY(QStringList sections READ sections WRITE setSections NOTIFY sectionsChanged)
+    Q_PROPERTY(QString username READ username WRITE setUsername NOTIFY usernameChanged)
 public:
     enum Source {
         NineGagSource,
@@ -64,11 +65,15 @@ public:
     QStringList sections() const;
     void setSections(const QStringList &sections);
 
+    QString username() const;
+    void setUsername(const QString &username);
+
 signals:
     void whiteThemeChanged();
     void sourceChanged();
     void scrollWithVolumeKeysChanged();
     void sectionsChanged();
+    void usernameChanged();
 
 private:
     Q_DISABLE_COPY(AppSettings)
@@ -78,6 +83,7 @@ private:
     Source m_source;
     bool m_scrollWithVolumeKeys;
     QStringList m_sections;
+    QString m_username;
 };
 
 #endif // APPSETTINGS_H

--- a/src/gagbookmanager.cpp
+++ b/src/gagbookmanager.cpp
@@ -69,6 +69,7 @@ void GagBookManager::login(const QString &username, const QString &password)
 {
     qDebug() << Q_FUNC_INFO;
     Q_ASSERT(m_netManager);
+    m_settings->setUsername(username); //save username so users don't have to input it everytime
     m_netManager->login(username, password);
 }
 

--- a/src/gagbookmanager.h
+++ b/src/gagbookmanager.h
@@ -38,6 +38,7 @@ class GagBookManager : public QObject
     Q_OBJECT
     Q_PROPERTY(QString downloadCounter READ downloadCounter NOTIFY downloadCounterChanged)
     Q_PROPERTY(AppSettings *settings READ settings WRITE setSettings)
+    Q_PROPERTY(bool loggedIn READ isLoggedIn NOTIFY loggedInChanged)
 public:
     explicit GagBookManager(QObject *parent = 0);
 
@@ -48,8 +49,14 @@ public:
 
     NetworkManager *networkManager() const;
 
+    bool isLoggedIn() const;
+
+    Q_INVOKABLE void login(const QString &username, const QString &password);
+    Q_INVOKABLE void logout();
+
 signals:
     void downloadCounterChanged();
+    void loggedInChanged();
 
 private:
     AppSettings *m_settings;

--- a/src/gagcookiejar.cpp
+++ b/src/gagcookiejar.cpp
@@ -61,7 +61,6 @@ void GagCookieJar::save()
 
     QSettings settings;
     settings.setValue("cookies", rawCookies);
-    qDebug() << Q_FUNC_INFO;
 }
 
 QList<QNetworkCookie> GagCookieJar::cookiesForUrl(const QUrl &url) const

--- a/src/gagcookiejar.cpp
+++ b/src/gagcookiejar.cpp
@@ -29,6 +29,8 @@
 
 #include <QtCore/QSettings>
 #include <QtNetwork/QNetworkCookie>
+#include <QDateTime>
+#include <QDebug>
 
 GagCookieJar::GagCookieJar(QObject *parent) :
     QNetworkCookieJar(parent)
@@ -39,6 +41,11 @@ GagCookieJar::GagCookieJar(QObject *parent) :
 }
 
 GagCookieJar::~GagCookieJar()
+{
+    this->save(); //save to file storage, otherwise they're gone when this instance is released from memory
+}
+
+void GagCookieJar::save()
 {
     QByteArray rawCookies;
     foreach (const QNetworkCookie cookie, allCookies()) {
@@ -54,6 +61,43 @@ GagCookieJar::~GagCookieJar()
 
     QSettings settings;
     settings.setValue("cookies", rawCookies);
+    qDebug() << Q_FUNC_INFO;
+}
+
+QList<QNetworkCookie> GagCookieJar::cookiesForUrl(const QUrl &url) const
+{
+    Q_UNUSED(url); //we never save any cookies that are not from 9gag.com (see this->save())
+    return allCookies();
+}
+
+bool GagCookieJar::setCookiesFromUrl(const QList<QNetworkCookie> &cookieList, const QUrl &url)
+{
+    bool addedCookies = false;
+
+    // lets save cookies for 90 days only
+    QDateTime soon = QDateTime::currentDateTime();
+    soon = soon.addDays(90);
+
+    foreach(QNetworkCookie cookie, cookieList) {
+        QList<QNetworkCookie> lst;
+        if (!cookie.isSessionCookie() && cookie.expirationDate() > soon) {
+            cookie.setExpirationDate(soon);
+        }
+        lst += cookie;
+        if (QNetworkCookieJar::setCookiesFromUrl(lst, url)) {
+            addedCookies = true;
+        } else {
+            // finally force it in if wanted
+            QList<QNetworkCookie> cookies = allCookies();
+            cookies += cookie;
+            setAllCookies(cookies);
+            addedCookies = true;
+        }
+    }
+
+    this->save(); //save to file storage, otherwise they're gone when this instance is released from memory
+
+    return addedCookies;
 }
 
 void GagCookieJar::clear()

--- a/src/gagcookiejar.h
+++ b/src/gagcookiejar.h
@@ -38,6 +38,12 @@ public:
     ~GagCookieJar();
 
     void clear();
+    void save();
+    QList<QNetworkCookie> cookiesForUrl(const QUrl &url) const;
+    bool setCookiesFromUrl(const QList<QNetworkCookie> &cookieList, const QUrl &url);
+
+signals:
+    void cookiesChanged();
 };
 
 #endif // GAGCOOKIEJAR_H

--- a/src/gagmodel.cpp
+++ b/src/gagmodel.cpp
@@ -42,6 +42,7 @@ GagModel::GagModel(QObject *parent) :
     m_selectedSection(0), m_request(0), m_imageDownloader(0), m_manualImageDownloader(0), m_downloadingIndex(-1)
 {
     _roles[TitleRole] = "title";
+    _roles[IdRole] = "id";
     _roles[UrlRole] = "url";
     _roles[ImageUrlRole] = "imageUrl";
     _roles[FullImageUrlRole] = "fullImageUrl";
@@ -52,6 +53,8 @@ GagModel::GagModel(QObject *parent) :
     _roles[IsNSFWRole] = "isNSFW";
     _roles[IsGIFRole] = "isGIF";
     _roles[IsPartialImageRole] = "isPartialImage";
+    _roles[IsLikedRole] = "isLiked";
+    _roles[IsDislikedRole] = "isDisliked";
     _roles[IsDownloadingRole] = "isDownloading";
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
     setRoleNames(_roles);
@@ -82,6 +85,8 @@ QVariant GagModel::data(const QModelIndex &index, int role) const
     switch (role) {
     case TitleRole:
         return gag.title();
+    case IdRole:
+        return gag.id();
     case UrlRole:
         return gag.url();
     case ImageUrlRole:
@@ -107,6 +112,10 @@ QVariant GagModel::data(const QModelIndex &index, int role) const
         return gag.isGIF();
     case IsPartialImageRole:
         return gag.isPartialImage();
+    case IsLikedRole:
+        return gag.isLiked();
+    case IsDislikedRole:
+        return gag.isDisliked();
     case IsDownloadingRole:
         return index.row() == m_downloadingIndex;
     default:

--- a/src/gagmodel.h
+++ b/src/gagmodel.h
@@ -58,6 +58,7 @@ class GagModel : public QAbstractListModel, public QQmlParserStatus
 public:
     enum Roles {
         TitleRole = Qt::UserRole,
+        IdRole,
         UrlRole,
         ImageUrlRole,
         FullImageUrlRole,
@@ -68,6 +69,8 @@ public:
         IsNSFWRole,
         IsGIFRole,
         IsPartialImageRole,
+        IsLikedRole,
+        IsDislikedRole,
         IsDownloadingRole
     };
 

--- a/src/gagobject.cpp
+++ b/src/gagobject.cpp
@@ -36,7 +36,8 @@ class GagObjectData : public QSharedData
 {
 public:
     GagObjectData() : votesCount(0), commentsCount(0),
-        isNSFW(false), isGIF(false), isPartialImage(false) {}
+        isNSFW(false), isGIF(false), isPartialImage(false),
+        isLiked(false), isDisliked(false) {}
     ~GagObjectData() {
         if (imageUrl.scheme() == "file")
             QFile::remove(imageUrl.toLocalFile());
@@ -56,6 +57,8 @@ public:
     bool isNSFW;
     bool isGIF;
     bool isPartialImage;
+    bool isLiked;
+    bool isDisliked;
 
 private:
     Q_DISABLE_COPY(GagObjectData) // Disable copy for the data
@@ -201,6 +204,26 @@ void GagObject::setIsPartialImage(bool isPartialImage)
     d->isPartialImage = isPartialImage;
 }
 
+bool GagObject::isLiked() const
+{
+    return d->isLiked;
+}
+
+void GagObject::setIsLiked(bool isLiked)
+{
+    d->isLiked = isLiked;
+}
+
+bool GagObject::isDisliked() const
+{
+    return d->isDisliked;
+}
+
+void GagObject::setIsDisliked(bool isDisliked)
+{
+    d->isDisliked = isDisliked;
+}
+
 QVariantMap GagObject::toVariantMap() const
 {
     QVariantMap gagMap;
@@ -215,5 +238,7 @@ QVariantMap GagObject::toVariantMap() const
     gagMap["isNSFW"] = d->isNSFW;
     gagMap["isGIF"] = d->isGIF;
     gagMap["isPartialImage"] = d->isPartialImage;
+    gagMap["isLiked"] = d->isLiked;
+    gagMap["isDisliked"] = d->isDisliked;
     return gagMap;
 }

--- a/src/gagobject.h
+++ b/src/gagobject.h
@@ -77,6 +77,12 @@ public:
     bool isPartialImage() const;
     void setIsPartialImage(bool isPartialImage);
 
+    bool isLiked() const;
+    void setIsLiked(bool isLiked);
+
+    bool isDisliked() const;
+    void setIsDisliked(bool isDisliked);
+
     QVariantMap toVariantMap() const;
     
 private:

--- a/src/networkmanager.cpp
+++ b/src/networkmanager.cpp
@@ -72,10 +72,16 @@ QNetworkReply *NetworkManager::createPostRequest(const QUrl &url, const QByteArr
     QNetworkRequest request;
     request.setUrl(url);
     request.setRawHeader("User-Agent", USER_AGENT);
+    request.setHeader(QNetworkRequest::ContentTypeHeader,
+                      "application/x-www-form-urlencoded");
+
+    m_networkAccessManager->setCookieJar(new GagCookieJar); //why is this needed? won't get cookies otherwise :/
     return m_networkAccessManager->post(request, data);
 }
 
 void NetworkManager::login(const QString username, const QString password) {
+    this->clearCookies();
+
     QUrlQuery postData;
     postData.addQueryItem("username", username);
     postData.addQueryItem("password", password);

--- a/src/networkmanager.cpp
+++ b/src/networkmanager.cpp
@@ -31,6 +31,12 @@
 #include <QtNetwork/QNetworkRequest>
 #include <QtNetwork/QNetworkReply>
 #include <QtNetwork/QNetworkConfiguration>
+#include <QtNetwork/QNetworkCookie>
+#include <QDebug>
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+#include <QUrlQuery>
+#endif
 
 #include "gagcookiejar.h"
 
@@ -41,7 +47,7 @@ NetworkManager::NetworkManager(QObject *parent) :
     m_downloadCounter(0), m_downloadCounterStr("0.00")
 {
     m_networkAccessManager->setCookieJar(new GagCookieJar);
-    connect(m_networkAccessManager, SIGNAL(finished(QNetworkReply*)), SLOT(increaseDownloadCounter(QNetworkReply*)));
+    connect(m_networkAccessManager, SIGNAL(finished(QNetworkReply*)), SLOT(replyFinished(QNetworkReply*)));
 }
 
 QNetworkReply *NetworkManager::createGetRequest(const QUrl &url, AcceptType acceptType)
@@ -69,6 +75,19 @@ QNetworkReply *NetworkManager::createPostRequest(const QUrl &url, const QByteArr
     return m_networkAccessManager->post(request, data);
 }
 
+void NetworkManager::login(const QString username, const QString password) {
+    QUrlQuery postData;
+    postData.addQueryItem("username", username);
+    postData.addQueryItem("password", password);
+
+    QNetworkRequest request(QUrl("http://9gag.com/login"));
+
+    request.setHeader(QNetworkRequest::ContentTypeHeader,
+                      "application/x-www-form-urlencoded");
+
+    m_networkAccessManager->post(request, postData.toString(QUrl::FullyEncoded).toUtf8());
+}
+
 bool NetworkManager::isMobileData() const
 {
     const QNetworkConfiguration activeConfiguration = m_networkAccessManager->activeConfiguration();
@@ -88,6 +107,8 @@ void NetworkManager::clearCookies()
     GagCookieJar *cookieJar = qobject_cast<GagCookieJar *>(m_networkAccessManager->cookieJar());
     Q_ASSERT(cookieJar != 0);
     cookieJar->clear();
+
+    emit loggedInChanged();
 }
 
 QString NetworkManager::downloadCounter() const
@@ -95,7 +116,7 @@ QString NetworkManager::downloadCounter() const
     return m_downloadCounterStr;
 }
 
-void NetworkManager::increaseDownloadCounter(QNetworkReply *reply)
+void NetworkManager::replyFinished(QNetworkReply *reply)
 {
     m_downloadCounter += reply->size();
     const QString downloadCounterStr = QString::number(qreal(m_downloadCounter) / 1024 / 1024, 'f', 2);
@@ -103,4 +124,44 @@ void NetworkManager::increaseDownloadCounter(QNetworkReply *reply)
         m_downloadCounterStr = downloadCounterStr;
         emit downloadCounterChanged();
     }
+
+    //this is to handle login/logout only
+    if(reply->error() == QNetworkReply::NoError) {
+        // Get the http status code
+        int v = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+
+        if (v >= 200 && v < 300) // Success
+        {
+            //no need to do anything
+        }
+        else if (v >= 300 && v < 400) // Redirection
+        {
+            // Redirection is expected when logging in, if login succesful we'll be directed to 9gag.com/
+
+            // Get the redirection url
+            QUrl newUrl = reply->attribute(QNetworkRequest::RedirectionTargetAttribute).toUrl();
+            // Because the redirection url can be relative,
+            // we have to use the previous one to resolve it
+            newUrl = reply->url().resolved(newUrl);
+
+            //save all the cookies we got from 9gag (including the loggedin one, which we'll use later)
+            QVariant variantCookies = reply->header(QNetworkRequest::SetCookieHeader);
+            QList<QNetworkCookie> cookies = qvariant_cast<QList<QNetworkCookie> >(variantCookies);
+
+            m_networkAccessManager->cookieJar()->setCookiesFromUrl(cookies, QUrl("9gag.com"));
+        }
+
+        //refresh the status in case we've been loggin in/logging out
+        emit loggedInChanged();
+    }
+    else
+    {
+        // Error
+        qDebug() << "Reply error: " << reply->errorString();
+    }
+}
+
+GagCookieJar *NetworkManager::cookieJar() const
+{
+    return qobject_cast<GagCookieJar *>(m_networkAccessManager->cookieJar());
 }

--- a/src/networkmanager.h
+++ b/src/networkmanager.h
@@ -29,6 +29,7 @@
 #define NETWORKMANAGER_H
 
 #include <QtCore/QObject>
+#include "gagcookiejar.h"
 
 class QNetworkAccessManager;
 class QNetworkReply;
@@ -54,13 +55,18 @@ public:
 
     void clearCookies();
 
+    GagCookieJar *cookieJar() const;
+
     QString downloadCounter() const;
+
+    void login(const QString username, const QString password);
 
 signals:
     void downloadCounterChanged();
+    void loggedInChanged();
 
 private slots:
-    void increaseDownloadCounter(QNetworkReply *reply);
+    void replyFinished(QNetworkReply *reply);
 
 private:
     Q_DISABLE_COPY(NetworkManager)

--- a/src/ninegagrequest.cpp
+++ b/src/ninegagrequest.cpp
@@ -99,6 +99,9 @@ static QList<GagObject> parseGAG(const QWebElementCollection &entryItems)
         gag.setCommentsCount(element.attribute("data-entry-comments").toInt());
         gag.setTitle(element.findFirst("a").toPlainText().trimmed());
 
+        gag.setIsLiked(!element.findFirst("ul.badge-item-vote-container.up").isNull());
+        gag.setIsDisliked(!element.findFirst("ul.badge-item-vote-container.down").isNull());
+
         const QWebElement postContainer = element.findFirst("div.post-container");
 
         if (!postContainer.findFirst("div.nsfw-post").isNull()) {

--- a/src/votingmanager.cpp
+++ b/src/votingmanager.cpp
@@ -1,0 +1,87 @@
+#include "votingmanager.h"
+
+#include <QMetaEnum>
+#include <QtNetwork/QNetworkReply>
+#include "networkmanager.h"
+#include <../qt-json/json.h>
+#include <QDebug>
+
+VotingManager::VotingManager(QObject *parent) :
+    QObject(parent), m_netManager(new NetworkManager(this))
+{  
+}
+
+void VotingManager::vote(VoteType type, const QString &id)
+{
+    Q_ASSERT(!id.isEmpty());
+
+    QUrl voteUrl("http://9gag.com/vote/"+ enumToString(type).toLower() +"/id/" + id);
+    qDebug() << "vote url: " << voteUrl;
+    QNetworkReply *m_reply = m_netManager->createPostRequest(voteUrl, QByteArray());
+    m_reply->setParent(this);
+    connect(m_reply, SIGNAL(finished()), this, SLOT(onReplyFinished()));
+}
+
+void VotingManager::setLike(const QString &id, bool liked)
+{
+    liked ? this->vote(Like,id) : this->vote(Unlike,id);
+}
+
+void VotingManager::setDislike(const QString &id, bool disliked)
+{
+    if (disliked)  //don't need to do anything when de-activating a Dislake
+        this->vote(Dislike,id);
+}
+
+void VotingManager::onReplyFinished()
+{
+    QNetworkReply *reply = qobject_cast<QNetworkReply *>(sender());
+    Q_ASSERT_X(reply != 0, Q_FUNC_INFO, "Unable to cast sender() to QNetworkReply *");
+
+    if (reply->error()) {
+        emit failure(reply->errorString());
+        reply->deleteLater();
+        reply = 0;
+        return;
+    }
+
+    QByteArray response = reply->readAll();
+    reply->deleteLater();
+    reply = 0;
+
+    bool ok;
+    const QVariantMap result = QtJson::parse(QString::fromUtf8(response), ok).toMap();
+
+    Q_ASSERT_X(ok, Q_FUNC_INFO, "Error parsing JSON");
+    Q_ASSERT_X(!result.isEmpty(), Q_FUNC_INFO, "Error parsing JSON or JSON is empty");
+
+    const QString msg = result.value("msg").toString();
+    const QString score = result.value("myScore").toString();
+    const QString id = result.value("id").toString();
+
+    if(msg == "Loved")
+        emit liked(id);
+
+    else if(msg == "Invalid vote.")
+        emit invalidVote();
+
+    else if(msg == "Not loved") { //this msg will be in 2 different cases, unliked+disliked, diffrence being the score
+        if (score == "-1")
+            emit disliked(id);
+        else if (score == "0")
+            emit unliked(id);
+        else
+            emit invalidVote();
+    }
+    else
+        emit invalidVote();
+
+}
+
+
+QString VotingManager::enumToString(VoteType aElement)
+{
+    int index = metaObject()->indexOfEnumerator("VoteType");
+    QMetaEnum metaEnum = metaObject()->enumerator(index);
+    return metaEnum.valueToKey(aElement);
+}

--- a/src/votingmanager.h
+++ b/src/votingmanager.h
@@ -1,0 +1,44 @@
+#ifndef VOTINGMANAGER_H
+#define VOTINGMANAGER_H
+
+#include <QObject>
+
+class NetworkManager;
+class QNetworkReply;
+
+class VotingManager : public QObject
+{
+    Q_OBJECT
+    Q_ENUMS(VoteType)
+
+public:
+    explicit VotingManager(QObject *parent = 0);
+
+    enum VoteType {
+        Like,
+        Unlike,
+        Dislike
+    };
+
+    Q_INVOKABLE void setLike(const QString &id, bool liked);
+    Q_INVOKABLE void setDislike(const QString &id, bool disliked);
+
+private slots:
+    void onReplyFinished();
+
+signals:
+    void liked(const QString &id);
+    void unliked(const QString &id);
+    void disliked(const QString &id);
+    void invalidVote();
+    void failure(const QString &errorMessage);
+
+private:
+    QString enumToString(VoteType aElement);
+    NetworkManager *m_netManager;
+    void vote(VoteType type, const QString &id);
+
+
+};
+
+#endif // VOTINGMANAGER_H


### PR DESCRIPTION
There are 2 (big) commits:
- Login/logout which resides in networkmanager (proxied to QML via gagbookmanager) + qml stuff for that.
  There are some minor issues still that we need to fix, mostly UI (like how to show wrong password since the request to login is async)
- Like/Dislike: i'm introducing a new class VotingManager that handles this via networkmanager. Like/dislike (and also unlike) are async POST-request to 9gag. I'm also getting the liked/disliked status from 9gag for each gag.
  Still some issues, my main one I need your help with is why model.isLiked setter isn't called when setting from QML. I just can't figure it out right now..

Anyways, comments and thoughts more than welcome. I've tried to follow your architecture as far as I could.
//bob
